### PR TITLE
Add the Vector Tiles extension to the Geoserver package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
       <version>${geoserver.version}</version>
       <type>pom</type>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver.extension</groupId>
+      <artifactId>gs-vectortiles</artifactId>
+      <version>${geoserver.version}</version>
+    </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
To be able to configure the new (vector tile output) formats to a layer, you first have to enable and configure WMTS. This service is disabled in the geoserver-core.