### PR TITLE
Updated to GeoServer `2.17.5` (minor update) + removed default user

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <artifactId>geoserver-core</artifactId>
   <name>GeoServer :: Core</name>
   <description>AERIUS Geoserver core package to be used by all GeoServer projects.</description>
-  <version>2.17.1-2-SNAPSHOT</version>
+  <version>2.17.5-1-SNAPSHOT</version>
   <packaging>war</packaging>
 
   <organization>
@@ -49,7 +49,7 @@
   </distributionManagement>
 
   <properties>
-    <geoserver.version>2.17.1</geoserver.version>
+    <geoserver.version>2.17.5</geoserver.version>
   </properties>
 
   <dependencies>

--- a/src/main/webapp/data/security/usergroup/default/users.xml
+++ b/src/main/webapp/data/security/usergroup/default/users.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><userRegistry xmlns="http://www.geoserver.org/security/users" version="1.0">
 <users>
-<user enabled="true" name="admin" password="digest1:vksuFo0Uoo8juZ7XYp4vgNAQWInO7YTxI6LRZWFq4OoCEBaenNupa2sueoOWvOTS"/>
 </users>
 <groups/>
 </userRegistry>


### PR DESCRIPTION
- GeoServer `2.17` is unmaintained and we should switch to the latest stable soon.
- Remove default user. Projects and/or developers needing an user account can override the file
as the file should be overlayed in such cases.
Removing this was planned for a while but we wanted to give projects time to get this sorted.
- Update library version numbers